### PR TITLE
Add support for replacing start and end of bibliography block

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ a warning will be displayed.
 The BibTeX file may, optionally, be provided or overridden on a per-article
 basis by supplying the meta-data `publications_src`.
 
+The HTML code for the start and of the bibliography section can be replaced via
+setting `BIBLIOGRAPHY_START` and `BIBLIOGRAPHY_END`. For example: 
+
+```python
+BIBLIOGRAPHY_START = '<section id="bib"><h1>My awesome bibliography</h1>'
+BIBLIOGRAPHY_END = '</section>' 
+``` 
+
 Attribution
 ===========
 `pelican-cite` is based on the

--- a/pelican_cite.py
+++ b/pelican_cite.py
@@ -54,6 +54,8 @@ class Style(UnsrtStyle):
 
 logger = logging.getLogger(__name__)
 global_bib = None
+bibliography_start = '<hr>\n<h2>Bibliography</h2>\n'
+bibliography_end = ''
 if pyb_imported:
     style = Style()
     backend = html.Backend()
@@ -110,7 +112,7 @@ def process_content(article):
 
     # Get the data for the required citations and append to content
     labels = {}
-    content += '<hr>\n<h2>Bibliography</h2>\n'
+    content += bibliography_start
     for formatted_entry in formatted_entries:
         key = formatted_entry.key
         ref_id = key.replace(' ','')
@@ -132,6 +134,8 @@ def process_content(article):
         text += '</p>'
         content += text + '\n'
         labels[key] = label
+
+    content += bibliography_end
 
     # Replace citations in article/page
     cite_count = {}
@@ -163,6 +167,11 @@ def add_citations(generators):
     if not pyb_imported:
         logger.warn('`pelican-cite` failed to load dependency `pybtex`')
         return
+
+    if 'BIBLIOGRAPHY_START' in pelican_instance.settings:
+        bibliography_start = pelican_instance.settings['BIBLIOGRAPHY_START']
+    if 'BIBLIOGRAPHY_END' in pelican_instance.settings:
+        bibliography_end = pelican_instance.settings['BIBLIOGRAPHY_END']
 
     if 'PUBLICATIONS_SRC' in generators[0].settings:
         refs_file = generators[0].settings['PUBLICATIONS_SRC']

--- a/pelican_cite.py
+++ b/pelican_cite.py
@@ -163,7 +163,7 @@ def process_content(article):
 
 
 def add_citations(generators):
-    global global_bib
+    global global_bib, bibliography_start, bibliography_end
     if not pyb_imported:
         logger.warn('`pelican-cite` failed to load dependency `pybtex`')
         return


### PR DESCRIPTION
This commit adds support for replacing the "Bibliography" header and also allows adding a section after the end of the bibliography. This is intended to:

* Change which heading to use (I need h1 instead of h2 for it to work well with the pelican-toc plugin).
* Add `<div>` or similar around the bibliography for CSS formatting.